### PR TITLE
Be/dev/fix jwt expiration exception#19

### DIFF
--- a/src/main/java/org/univcabi/univcabi/auth/controller/AuthnController.java
+++ b/src/main/java/org/univcabi/univcabi/auth/controller/AuthnController.java
@@ -118,8 +118,9 @@ public class AuthnController {
         UserDetails userDetails = (UserDetails) principal;
         String studentNumber = userDetails.getUsername();
 
+        //해당 사용자의 contextHolder 정보 삭제
         SecurityContextHolder.clearContext();
-
+        //해당 사용자의 redis의 refreshToken 정보 삭제
         tokenService.deleteRefreshToken(studentNumber);
 
         ResponseCookie deleteCookie = ResponseCookie.from("refreshToken","")

--- a/src/main/java/org/univcabi/univcabi/auth/controller/AuthnController.java
+++ b/src/main/java/org/univcabi/univcabi/auth/controller/AuthnController.java
@@ -89,6 +89,9 @@ public class AuthnController {
 
         String refreshToken = jwtTokenProvider.generateRefreshToken(requestDto.getStudentNumber());
 
+        // redis에 refreshToken 저장
+        tokenService.storeRefreshToken(tokenVo.studentNumber(),refreshToken);
+
         ResponseCookie refreshCookie = tokenService.createRefreshTokenCookie(refreshToken);
         // 로그인 성공시 accessToken 발급 ( 응답의 body 값 )
         AuthnLoginResponseDto responseDto = AuthnLoginResponseDto.builder().accessToken(accessToken).build();

--- a/src/main/java/org/univcabi/univcabi/auth/controller/TokenController.java
+++ b/src/main/java/org/univcabi/univcabi/auth/controller/TokenController.java
@@ -2,6 +2,7 @@ package org.univcabi.univcabi.auth.controller;
 
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,6 +18,7 @@ import java.io.IOException;
 
 import static org.univcabi.univcabi.exception.ExceptionStatus.AUTH_MISMATCH_REFRESH_TOKEN;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 public class TokenController {
@@ -32,10 +34,12 @@ public class TokenController {
                                                                     HttpServletResponse response) throws IOException {
 
         // 토큰 만료 확인 ( json 형태의 응답이 필요해서 Servlet 사용)
-        if(jwtTokenProvider.validateToken(refreshToken)){
+        if(!jwtTokenProvider.validateToken(refreshToken)){
+            log.warn("RefreshToken 만료");
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             response.setContentType("application/json");
             response.getWriter().write("{\"messages\": [{\"token_class\": \"RefreshToken\"}]}");
+            return null;
         }
 
         String studentNumber = jwtTokenProvider.getStudentNumberFromToken(refreshToken);
@@ -49,6 +53,8 @@ public class TokenController {
         // 새로운 accessToken 발급
         AuthnRole role = authnService.getUserRole(studentNumber);
         String newAccessToken = jwtTokenProvider.generateAccessToken(studentNumber,role);
+
+        log.info("RefreshToken 인증 성공, 새로운 AccessToken 발급 완료");
 
         return ResponseEntity.ok(AuthnLoginResponseDto.builder()
                 .accessToken(newAccessToken)

--- a/src/main/java/org/univcabi/univcabi/auth/controller/TokenController.java
+++ b/src/main/java/org/univcabi/univcabi/auth/controller/TokenController.java
@@ -1,7 +1,7 @@
 package org.univcabi.univcabi.auth.controller;
 
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -11,6 +11,11 @@ import org.univcabi.univcabi.auth.entity.AuthnRole;
 import org.univcabi.univcabi.auth.security.JwtTokenProvider;
 import org.univcabi.univcabi.auth.service.AuthnService;
 import org.univcabi.univcabi.auth.service.TokenService;
+import org.univcabi.univcabi.exception.MiddlewareException;
+
+import java.io.IOException;
+
+import static org.univcabi.univcabi.exception.ExceptionStatus.AUTH_MISMATCH_REFRESH_TOKEN;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,12 +26,28 @@ public class TokenController {
     private final JwtTokenProvider jwtTokenProvider;
 
 
+    // RefreshToken 관련 예외 책임은 전부 여기로
     @PostMapping("/authn/token/access")
-    public ResponseEntity<AuthnLoginResponseDto> refreshAccessToken(@CookieValue(value = "refreshToken")String refreshToken){
+    public ResponseEntity<AuthnLoginResponseDto> refreshAccessToken(@CookieValue(value = "refreshToken")String refreshToken,
+                                                                    HttpServletResponse response) throws IOException {
+
+        // 토큰 만료 확인 ( json 형태의 응답이 필요해서 Servlet 사용)
+        if(jwtTokenProvider.validateToken(refreshToken)){
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setContentType("application/json");
+            response.getWriter().write("{\"messages\": [{\"token_class\": \"RefreshToken\"}]}");
+        }
+
         String studentNumber = jwtTokenProvider.getStudentNumberFromToken(refreshToken);
 
-        AuthnRole role = authnService.getUserRole(studentNumber);
+        // redis의 refreshToken 과 요청의 refreshToken 일치 여부 확인
+        String storedToken = tokenService.getRefreshToken(studentNumber);
+        if(storedToken ==null|| !storedToken.equals(refreshToken)){
+            throw new MiddlewareException(AUTH_MISMATCH_REFRESH_TOKEN);
+        }
 
+        // 새로운 accessToken 발급
+        AuthnRole role = authnService.getUserRole(studentNumber);
         String newAccessToken = jwtTokenProvider.generateAccessToken(studentNumber,role);
 
         return ResponseEntity.ok(AuthnLoginResponseDto.builder()

--- a/src/main/java/org/univcabi/univcabi/auth/security/CustomUserDetailsService.java
+++ b/src/main/java/org/univcabi/univcabi/auth/security/CustomUserDetailsService.java
@@ -2,6 +2,7 @@ package org.univcabi.univcabi.auth.security;
 
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -9,8 +10,11 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.univcabi.univcabi.auth.entity.Authn;
 import org.univcabi.univcabi.auth.repository.AuthnRepository;
+import org.univcabi.univcabi.exception.ServiceException;
 
-import java.util.Collections;
+import java.util.List;
+
+import static org.univcabi.univcabi.exception.ExceptionStatus.USER_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -20,12 +24,14 @@ public class CustomUserDetailsService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String studentNumber) throws UsernameNotFoundException {
         Authn authn = authnRepository.findByStudentNumber(studentNumber)
-                .orElseThrow(()-> new UsernameNotFoundException("유저를 찾을 수 없습니다: "+studentNumber));
+                .orElseThrow(()-> new ServiceException(USER_NOT_FOUND));
+
+        String roleName = "ROLE_" + authn.getRole().name(); // ROLE_ADMIN, ROLE_NORMAL
 
         return User.builder()
                 .username(authn.getStudentNumber())
                 .password(authn.getPassword())
-                .authorities(Collections.emptyList())
+                .authorities(List.of(new SimpleGrantedAuthority(roleName))) // 이후 해당 권한 정보로 controller에서 권한 기반 접근 제어가 가능 ex) @PreAuthorize("hasRole('ADMIN')")
                 .build();
     }
 

--- a/src/main/java/org/univcabi/univcabi/auth/security/JwtAuthenticationFilter.java
+++ b/src/main/java/org/univcabi/univcabi/auth/security/JwtAuthenticationFilter.java
@@ -12,7 +12,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.web.filter.OncePerRequestFilter;
-import org.univcabi.univcabi.auth.entity.AuthnRole;
 import org.univcabi.univcabi.auth.service.AuthnService;
 import org.univcabi.univcabi.auth.service.TokenService;
 
@@ -43,50 +42,18 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
 
         try {
-            String token = resolveToken(request);
-            // 나중에 null 처리 로직 리팩토링 필요해 보임
-            if (token != null) {
-                try {
-                    if (jwtTokenProvider.validateToken(token)) {
-                        authenticateUser(token);
-                    }
-                } catch (ExpiredJwtException e) {
-                    log.warn("AccessToken이 만료됨. RefreshToken으로 재발급 시도");
+            String accessToken = resolveToken(request);
+            if (jwtTokenProvider.validateToken(accessToken)) {
+                // accessToken 정상적인 경우 인증 정보 세팅
+                authenticateUser(accessToken);
+            } else {
+                log.warn("AccessToken 만료");
 
-                    try {
-                        String refreshToken = tokenService.getRefreshTokenFromCookie(request);
-                        if (refreshToken != null && jwtTokenProvider.validateToken(refreshToken)) {
-                            String studentNumber = jwtTokenProvider.getStudentNumberFromToken(refreshToken);
-                            String storedRefreshToken = tokenService.getRefreshToken(studentNumber);
-                            if (refreshToken.equals(storedRefreshToken)) {
-                                AuthnRole role = authnService.getUserRole(studentNumber);
-                                String newAccessToken = jwtTokenProvider.generateAccessToken(studentNumber, role);
-                                response.setHeader("Authorization", "Bearer " + newAccessToken);
-                                log.info("새로운 AccessToken 발급 및 쿠키 저장 완료");
-                                authenticateUser(newAccessToken);
-                            } else {
-                                log.error("RefreshToken이 유효하지 않음. 재발급 불가");
-                                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Refresh Token이 유효하지 않음");
-                                return;
-                            }
-                        } else {
-                            log.error("RefreshToken이 존재하지 않거나 유효하지 않음.");
-                            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Refresh Token이 유효하지 않음");
-                            return;
-                        }
-                    } catch (Exception refreshException) {
-                        log.error("RefreshToken 처리 중 오류 발생: {}", refreshException.getMessage());
-                        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "인증 처리 중 오류 발생");
-                        return;
-                    }
-                } catch (Exception e) {
-                    log.error("Token 처리 중 예외 발생: {}", e.getMessage());
-                    response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "인증 처리 중 오류 발생");
-                    return;
-                }
+                // 401 && response.data.messages[0].token_class
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.setContentType("application/json");
+                response.getWriter().write("{\"messages\": [{\"token_class\": \"AccessToken\"}]}");
             }
-
-            filterChain.doFilter(request, response);
         } catch (Exception e) {
             // 필터 처리 중 발생한 예외는 여기서 잡아서 원래 예외를 유지
             log.error("JWT 필터 처리 중 예외 발생: {}", e.getMessage(), e);
@@ -106,7 +73,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 "/api/auth/signup",
                 "/api/auth/refresh",
                 "/api/public",   // 퍼블릭 API 경로 등
-                "/api/user/mockup"
+                "/api/user/mockup",
+                "/api/authn/token/access"
         );
 
         String path = request.getRequestURI();
@@ -124,6 +92,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         UsernamePasswordAuthenticationToken authentication =
                 new UsernamePasswordAuthenticationToken(userDetails,null,userDetails.getAuthorities());
 
+        // JWT는 stateless 이기 때문에 매 요청마다 토큰을 검사해서 인증 정보를 새로 세팅 해줌
         SecurityContextHolder.getContext().setAuthentication(authentication);
         log.info("JWT 인증 성공 : {}",studentNumber);
     }

--- a/src/main/java/org/univcabi/univcabi/auth/security/JwtAuthenticationFilter.java
+++ b/src/main/java/org/univcabi/univcabi/auth/security/JwtAuthenticationFilter.java
@@ -27,8 +27,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final UserDetailsService userDetailsService;
-    private final TokenService tokenService;
-    private final AuthnService authnService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -44,17 +42,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         try {
             String accessToken = resolveToken(request);
             if (jwtTokenProvider.validateToken(accessToken)) {
-                // accessToken 정상적인 경우 인증 정보 세팅
                 authenticateUser(accessToken);
-            } else {
-                log.warn("AccessToken 만료");
-
-                // 401 && response.data.messages[0].token_class
+                filterChain.doFilter(request, response); // 누락시에 controller 로 그 다음 요청이 이동하지않음 중요!
+                return;
+            } else{
+                log.warn("AccessToken 만료됨");
                 response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
                 response.setContentType("application/json");
                 response.getWriter().write("{\"messages\": [{\"token_class\": \"AccessToken\"}]}");
-            }
-        } catch (Exception e) {
+                return;}
+        }catch (Exception e) {
             // 필터 처리 중 발생한 예외는 여기서 잡아서 원래 예외를 유지
             log.error("JWT 필터 처리 중 예외 발생: {}", e.getMessage(), e);
             // 이미 응답이 커밋되지 않았다면 에러 전송
@@ -69,12 +66,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private boolean shouldSkipFilter(HttpServletRequest request) {
         // 인증이 필요 없는 경로 목록
         final List<String> excludedPaths = Arrays.asList(
-                "/api/auth/login",
+                "/api/authn/login",
+                "/authn/login",
                 "/api/auth/signup",
                 "/api/auth/refresh",
                 "/api/public",   // 퍼블릭 API 경로 등
                 "/api/user/mockup",
-                "/api/authn/token/access"
+                "/authn/token/access"
         );
 
         String path = request.getRequestURI();

--- a/src/main/java/org/univcabi/univcabi/auth/security/JwtTokenProvider.java
+++ b/src/main/java/org/univcabi/univcabi/auth/security/JwtTokenProvider.java
@@ -13,6 +13,7 @@ import java.util.*;
 
 @Slf4j
 @Component
+// JWT 생성 + 파싱 + 검증 담당
 public class JwtTokenProvider {
     private final SecretKey key;
     private final long accessTokenExpiration;
@@ -27,22 +28,22 @@ public class JwtTokenProvider {
 
     }
 
+    // JWT 생성 (문자열 반환)
     private String createToken(String studentNumber, AuthnRole role, long expirationTime) {
         Date now = new Date();
         Date expiryDate = new Date(now.getTime() + expirationTime);
 
         Map<String, Object> claims = new HashMap<>();
-        claims.put("sub",studentNumber);
-        claims.put("iat",now);
 
         Optional.ofNullable(role).ifPresent(r-> claims.put("role", r.name())); // ADMIN, NORMAL
 
         return Jwts.builder()
+                .subject(studentNumber)
                 .claims(claims)
                 .issuedAt(now)
                 .expiration(expiryDate)
                 .signWith(key)
-                .compact();
+                .compact(); // Header, Payload, Signature 를 묶어서 문자열로 반환
     }
 
     public String generateAccessToken(String studentNumber, AuthnRole role) {
@@ -58,19 +59,15 @@ public class JwtTokenProvider {
             Jwts.parser()
                     .verifyWith((SecretKey) key)
                     .build()
-                    .parseSignedClaims(token);
+                    .parseSignedClaims(token); // 해쉬기반 서명 검증 + 만료 검증
             return true;
-        } catch (ExpiredJwtException e) {
-            log.warn("만료된 JWT: {}", e.getMessage());
-            throw e;
-        } catch (JwtException e) {
-            log.warn("유효하지 않은 JWT: {}", e.getMessage());
+        } catch (JwtException e){
+            log.warn("JWT 유효성 검증 실패: {}",e.getMessage());
+            return false;
         }
-        return false;
     }
 
     public String getStudentNumberFromToken(String token) {
-
         return Jwts.parser()
                 .verifyWith((SecretKey) key)
                 .build()
@@ -79,17 +76,4 @@ public class JwtTokenProvider {
                 .getSubject();
     }
 
-    public Date getExpirationDate(String token) {
-        return Jwts.parser()
-                .verifyWith((SecretKey) key)
-                .build()
-                .parseSignedClaims(token)
-                .getPayload()
-                .getExpiration();
-    }
-
-    public boolean isTokenExpired(String token){
-        Date expirationDate = getExpirationDate(token);
-        return expirationDate.before(new Date());
-    }
 }

--- a/src/main/java/org/univcabi/univcabi/configs/SecurityConfig.java
+++ b/src/main/java/org/univcabi/univcabi/configs/SecurityConfig.java
@@ -28,8 +28,7 @@ public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final CustomUserDetailsService customUserDetailsService;
-    private final TokenService tokenService;
-    private final AuthnService authnService;
+
 
 
     @Bean
@@ -53,7 +52,7 @@ public class SecurityConfig {
                                 "/api/v1/cabinet/**")
                         .permitAll() //로그인 api는 인증 없이 가능
                         .anyRequest().authenticated())
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider,customUserDetailsService,tokenService,authnService),
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider,customUserDetailsService),
                         UsernamePasswordAuthenticationFilter.class); // JWT 인증 필터 추가
 
         return http.build();

--- a/src/main/java/org/univcabi/univcabi/exception/ExceptionStatus.java
+++ b/src/main/java/org/univcabi/univcabi/exception/ExceptionStatus.java
@@ -18,6 +18,7 @@ public enum ExceptionStatus {
     AUTH_COOKIE_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "잘못된 쿠키로 접근했습니다"),
     AUTH_SESSION_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "잘못된 세션으로 접근했습니다"),
     AUTH_MISMATCH_PASSWORD(HttpStatus.UNAUTHORIZED,"비밀번호 불일치"),
+    AUTH_MISMATCH_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED,"리프레시 토큰 불일치."),
 
     // CABINET ERROR CODE
     CABINET_INVALID_ID(HttpStatus.BAD_REQUEST, "잘못된 사물함 ID입니다"),

--- a/src/main/java/org/univcabi/univcabi/user/controller/UserController.java
+++ b/src/main/java/org/univcabi/univcabi/user/controller/UserController.java
@@ -13,7 +13,6 @@ import org.univcabi.univcabi.user.vo.UserVisibilityVo;
 import org.springframework.security.core.Authentication;
 
 
-import static org.univcabi.univcabi.util.TokenUtils.resolveToken;
 
 @RestController
 @RequestMapping("/user")

--- a/src/main/java/org/univcabi/univcabi/util/TokenUtils.java
+++ b/src/main/java/org/univcabi/univcabi/util/TokenUtils.java
@@ -2,6 +2,9 @@ package org.univcabi.univcabi.util;
 
 
 import jakarta.servlet.http.HttpServletRequest;
+import org.univcabi.univcabi.exception.UtilException;
+
+import static org.univcabi.univcabi.exception.ExceptionStatus.AUTH_COOKIE_UNAUTHORIZED;
 
 public class TokenUtils {
     // util 클래스이므로 인스턴스 호출 금지
@@ -13,9 +16,8 @@ public class TokenUtils {
             return bearerToken.substring(7);
         }
         else{
-            // 나중에 null 처리 로직 리팩토링 필요해 보임
-            return null;
-//          throw new IllegalArgumentException("유효하지 않은 accessToken");
+            // 잘못된 토큰 요청시 예외 처리
+          throw new UtilException(AUTH_COOKIE_UNAUTHORIZED);
         }
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #19 

## 📝작업 내용

> 기존에 문제점이 accessToken 이 만료될시에 refresh가 제대로 발급이 안되는 문제가 있었습니다. ( 잘못된 요청으로 예외로직에서 만료시키는 로직은 없었습니다 그냥 제가 accessToken 시간을 18초로 해놨더라구요;;;)  프론트의 axios 요청에 맞게 응답 값을 수정하여 해결하였습니다.

> dofilter 함수의 엉망진창인 try catch 문을 손봤습니다. (사실 필요없는 예외가 너무 많았어서... 실제로 동작도안하는) 
> 그 과정에서 accessToken 관련해서는 middleware에서 확실히 예외처리를 하고 /authn/token/access 로 요청하는 로직에 따라 refresh 관련한 예외처리는 Tokencontroller 에서 처리했습니다. (예외에있어서 controller 지만 middleware의 느낌이 강해서 예외처리를 middleware로 처리했고 또 만료시 반환은 servlet으로 처리했는데 이것은 반환 메세지 json 형태를 쉽게 다룰려고 servlet을 사용했습니다)

> 이게 빨리 할줄 알았는데 잘 못 수정했다가 난리날까봐 조심조심 만졌습니다. (실제로 무한 access 요청 일어났을땐 멘탈이..)


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰 별점 남겨주세요