### PR TITLE
관리자 사물함 상태 변경시 나타나는 에러 해결

### DIFF
--- a/src/main/java/org/univcabi/univcabi/cabinet/controller/CabinetController.java
+++ b/src/main/java/org/univcabi/univcabi/cabinet/controller/CabinetController.java
@@ -317,12 +317,12 @@ public class CabinetController {
     @GetMapping("/status/search")
     @Operation(summary = "사물함 상태별 조회")
     public ResponseEntity<CabinetPageResponseDto<CabinetByStatusResponseDto>> findCabinetsByStatus(
-            @ModelAttribute CabinetSearchByStatusRequestDto requestDto,
+            @ModelAttribute @Valid CabinetSearchByStatusRequestDto requestDto,
             HttpServletRequest request
     ){
-        // Pageable 생성
+        // Pageable 생성 page는 null 이면 0부터 jap는 0 부터 시작이기에 1값이 들어오면 0 페이지부터
         Pageable pageable = PageRequest.of(
-                Optional.ofNullable(requestDto.getPage()).orElse(0),
+                requestDto.getPage() != null ? Math.max(0, requestDto.getPage() - 1) : 0,
                 Optional.ofNullable(requestDto.getPageSize()).orElse(12)
         );
 

--- a/src/main/java/org/univcabi/univcabi/cabinet/dto/request/CabinetSearchByStatusRequestDto.java
+++ b/src/main/java/org/univcabi/univcabi/cabinet/dto/request/CabinetSearchByStatusRequestDto.java
@@ -1,6 +1,7 @@
 package org.univcabi.univcabi.cabinet.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -14,7 +15,7 @@ import org.univcabi.univcabi.cabinet.entity.CabinetStatus;
 @AllArgsConstructor
 public class CabinetSearchByStatusRequestDto {
 
-    @NotBlank
+    @NotNull(message = "상태는 필수입니다")
     private CabinetStatus status;
 
     private Integer page;

--- a/src/main/java/org/univcabi/univcabi/cabinet/dto/response/CabinetByStatusResponseDto.java
+++ b/src/main/java/org/univcabi/univcabi/cabinet/dto/response/CabinetByStatusResponseDto.java
@@ -28,12 +28,18 @@ public class CabinetByStatusResponseDto {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.M.d")
     private LocalDate brokenDate;
 
+    @Data
     @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class Position{
         private int x,y;
     }
 
+    @Data
     @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class User{
         private String name;
         private String studentNumber;

--- a/src/main/java/org/univcabi/univcabi/cabinet/service/AdminCabinetService.java
+++ b/src/main/java/org/univcabi/univcabi/cabinet/service/AdminCabinetService.java
@@ -134,6 +134,7 @@ public class AdminCabinetService {
                 }
                 // 연체 상태로 변경 및 history의 updatedAt, expiredAt 정보 변경
                 case OVERDUE -> {
+                    cabinet.setUser(user);
                     cabinet.setStatus(status);
                     CabinetHistory lateHistory = cabinetHistoryRepository.findLatestActiveHistoryByCabinetId(cabinet.getId());
                     if(lateHistory!=null) {

--- a/src/main/java/org/univcabi/univcabi/cabinet/vo/CabinetStatusVo.java
+++ b/src/main/java/org/univcabi/univcabi/cabinet/vo/CabinetStatusVo.java
@@ -2,6 +2,6 @@ package org.univcabi.univcabi.cabinet.vo;
 
 import org.univcabi.univcabi.cabinet.entity.CabinetStatus;
 
-public record CabinetStatusVo (CabinetStatus status
-){
+public record CabinetStatusVo (
+        CabinetStatus status){
 }

--- a/src/main/java/org/univcabi/univcabi/user/vo/RentCabinetInfoVo.java
+++ b/src/main/java/org/univcabi/univcabi/user/vo/RentCabinetInfoVo.java
@@ -1,6 +1,7 @@
 package org.univcabi.univcabi.user.vo;
 
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 
@@ -12,7 +13,8 @@ public record RentCabinetInfoVo (
          LocalDateTime startDate,
          LocalDateTime endDate
 ) {
+    // endDate 값이 null 일시에 default 로 현재로부터 2주 후가 endDate가 되도록 설정
     public int leftDate(){
-        return (int) ChronoUnit.DAYS.between(LocalDateTime.now(),endDate);
+        return (int) ChronoUnit.DAYS.between(LocalDateTime.now(),endDate == null? LocalDateTime.now().plusWeeks(2):endDate);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #32 

## 📝작업 내용

> 연체 혹은 고장 사물함 이 있어도 사물함 테이블 리스트에 정보가 나타나지 않았던 문제 가 있었습니다.
![image](https://github.com/user-attachments/assets/a84c2280-fa97-4ac4-b487-bde7881268f1)

> 해결했습니다.
![image](https://github.com/user-attachments/assets/9be0eb4f-8666-4bf0-ba59-b29dfec35d31)

> 또한 기존 DB에는 endDate가 전부 설정되어있었는데 새로운 사물함이 생길시 endDate값이 null이 되면서 메서드에서 발생한 nullPointerException을 해결해봤습니다.
## 💬리뷰 요구사항(선택)

> 이렇게 고치는게 맞 겠 죠?
